### PR TITLE
Outlier detection and fix

### DIFF
--- a/README-outlier-detection.md
+++ b/README-outlier-detection.md
@@ -58,6 +58,8 @@ ZERO_DROP_CONFIG: dict[str, dict[str, float]] = {
 		"normal_threshold": 20.0, # Previous value must be above this to trigger zero-drop detection
 	}
 }
+```
+
 
 **Effect for TVOC:**
 - If a reading goes from, for example, 70 → 0 or 225 → 0:

--- a/README-outlier-detection.md
+++ b/README-outlier-detection.md
@@ -1,8 +1,8 @@
-# Radoff Now Sensor – Outlier Detection (v5)
+# Radoff Now Sensor – Outlier Detection
 
 ## Overview
 
-This version (v5) extends the original Radoff Now Home Assistant integration with robust outlier handling, while keeping normal sensor behavior unchanged.
+This change extends the original Radoff Now Home Assistant integration with robust outlier handling, while keeping normal sensor behavior unchanged.
 
 **Key idea:**  
 - Normal readings are passed through as-is.  
@@ -55,13 +55,7 @@ ZERO_DROP_CONFIG: dict[str, dict[str, float]] = {
 "tvoc": {
 "low_threshold": 1.0, # Values below this are considered "zero"
 "normal_threshold": 20.0, # Previous value must be above this to trigger zero-drop detection
-},
-# Example for adding more:
-# "eco2": {
-# "low_threshold": 100.0,
-# "normal_threshold": 400.0,
-# },
-}
+}}
 
 text
 
@@ -122,7 +116,7 @@ When no outlier is detected:
 
 ---
 
-## Examples (based on your data)
+## Examples
 
 ### 1) Temperature spike
 
@@ -136,7 +130,7 @@ When no outlier is detected:
 - Index: “good” → “terrible” → “good”  
 - Graph: Strong spike to 52°C.
 
-**v5 integration:**
+**Outlier detection integration:**
 - State: 20.5 → median(history) ≈ 20.5 → 20.8  
 - Index: consistent “good” readings  
 - Graph: No erroneous 52°C spike.
@@ -161,7 +155,7 @@ Example raw patterns:
 **Original integration:**
 - TVOC briefly drops to 0 → graph shows dips to 0 → misleading for interpretation.
 
-**v5 integration:**
+**Outlier detection integration:**
 - For these readings:
   - Marked as zero-drop outliers.
   - Replaced by median of recent valid TVOC values (e.g. around previous level).
@@ -218,55 +212,9 @@ All other behavior (device info, translation keys, index mapping, etc.) retains 
 
 ---
 
-## Installation
-
-1. **Backup original:**
-cp custom_components/radoff/sensor.py custom_components/radoff/sensor.py.backup
-
-text
-
-2. **Replace with v5:**
-- Save this file as `sensor.py` in `custom_components/radoff/`.
-
-3. **(Optional) Adjust thresholds:**
-- Edit `OUTLIER_THRESHOLDS` and `ZERO_DROP_CONFIG` to match your environment.
-- For TVOC, keep:
-  ```
-  "tvoc": 150.0
-  ```
-  and rely on `ZERO_DROP_CONFIG` to catch zero-drops.
-
-4. **Restart Home Assistant:**
-- Via UI: Developer Tools → Services → *Homeassistant: Restart*  
-- Or via shell:
-  ```
-  sudo systemctl restart home-assistant
-  ```
-
----
-
-## Logging and debugging
-
-Enable debug logging in `configuration.yaml`:
-
-logger:
-default: info
-logs:
-custom_components.radoff.sensor: debug
-
-text
-
-You will see:
-
-- Warnings for zero-drops and threshold outliers.
-- Info logs for median replacement.
-- Debug logs when index sensors are suppressed because base values were filtered.
-
----
-
 ## Summary
 
-v5 keeps your sensor behavior natural for normal operation, but:
+This change keeps your sensor behavior natural for normal operation, but:
 
 - Eliminates spurious TVOC zero readings.
 - Suppresses unrealistic spikes (e.g. 52°C).

--- a/README-outlier-detection.md
+++ b/README-outlier-detection.md
@@ -1,0 +1,274 @@
+# Radoff Now Sensor – Outlier Detection (v5)
+
+## Overview
+
+This version (v5) extends the original Radoff Now Home Assistant integration with robust outlier handling, while keeping normal sensor behavior unchanged.
+
+**Key idea:**  
+- Normal readings are passed through as-is.  
+- Only detected outliers are replaced (using a small history-based median).  
+- Index sensors use the cleaned base values, not raw ones.
+
+---
+
+## Changes compared to original code
+
+| Aspect | Original | v5 (this version) |
+| --- | --- | --- |
+| Value processing | Raw sensor value is passed through | Raw value is used unless flagged as outlier |
+| Outlier detection | None | Hybrid: zero-drop rule + delta-threshold |
+| History tracking | None | Last 3 valid values per base sensor |
+| Median usage | Not used | Only used when replacing detected outliers |
+| Index sensors | Based on raw values | Based on cleaned base values; suppressed if base is suppressed |
+| Configuration | Only INDEX_MAPPING | Adds OUTLIER_THRESHOLDS and ZERO_DROP_CONFIG |
+
+---
+
+## New configuration parameters
+
+### OUTLIER_THRESHOLDS
+
+Used for general outlier detection based on change magnitude from the last valid value.
+
+OUTLIER_THRESHOLDS: dict[str, float] = {
+"internal_temperature": 5.0, # Max 5°C change between readings
+"tvoc": 150.0, # Max 150 V-lx change
+"eco2": 500.0, # Max 500 ppm change
+"relative_humidity": 15.0, # Max 15% change
+"pm1": 50.0,
+"pm25": 50.0,
+"pm10": 50.0,
+"pressure": 1000.0, # Max 1000 Pa change
+}
+
+text
+
+- These values can be tuned per sensor.
+- For TVOC, a relatively high threshold (150.0) is used so that legitimate large jumps (e.g. 196 → 96) are not suppressed.  
+- Zero-drops to 0 are handled separately (see below).
+
+### ZERO_DROP_CONFIG
+
+Used for sensor-specific detection of “drops to zero / near-zero” from normal values.
+
+ZERO_DROP_CONFIG: dict[str, dict[str, float]] = {
+"tvoc": {
+"low_threshold": 1.0, # Values below this are considered "zero"
+"normal_threshold": 20.0, # Previous value must be above this to trigger zero-drop detection
+},
+# Example for adding more:
+# "eco2": {
+# "low_threshold": 100.0,
+# "normal_threshold": 400.0,
+# },
+}
+
+text
+
+**Effect for TVOC:**
+- If a reading goes from, for example, 70 → 0 or 225 → 0:
+  - Current value `< 1.0`
+  - Previous value `> 20.0`
+  - This is flagged as a zero-drop outlier, regardless of the 150-threshold.
+
+---
+
+## Outlier detection logic
+
+### Method: `_is_outlier_detected`
+
+1. If there is no previous valid value, no outlier is detected.
+2. If there is no threshold configured for this sensor key, no outlier is detected.
+3. **Zero-drop check (sensor-specific, for keys in `ZERO_DROP_CONFIG`):**
+   - If `current_value < low_threshold` **and**
+   - `last_valid_value > normal_threshold`  
+   → Zero-drop outlier detected (e.g. TVOC dropping from 90 to 0).
+4. **Threshold check (all supported sensors):**
+   - `change = abs(current_value - last_valid_value)`  
+   - If `change > OUTLIER_THRESHOLDS[sensor_key]`  
+   → Threshold outlier detected (e.g. temperature 20.5°C → 52.2°C).
+
+---
+
+## Replacement strategy
+
+When `_is_outlier_detected()` returns `True`:
+
+1. If there is history (up to last 3 non-outlier values):
+   - Compute median using `_calculate_median` and return it as the cleaned value.
+2. Else if there is a `_last_valid_value`:
+   - Re-use `_last_valid_value`.
+3. Else (no history and no last valid value):
+   - Skip this reading: return `None` and store `None` for the index sensor.
+
+When no outlier is detected:
+
+- The raw (normalized) value is:
+  - Added to the history buffer (`_value_history`),  
+  - Stored as `_last_valid_value`,  
+  - Written to `_FILTERED_VALUES` for index sensors,  
+  - Returned as the sensor state.
+
+---
+
+## Behavior of index sensors
+
+- Index sensors no longer perform their own filtering or history management.
+- They obtain the filtered base sensor value from `_FILTERED_VALUES[device_id][sensor_key]`.
+- If the base value is `None` (outlier skipped), the index sensor returns `None` as well and does not update.
+- This ensures:
+  - Indices are always based on cleaned data.
+  - No index is produced for readings that were suppressed as outliers.
+
+---
+
+## Examples (based on your data)
+
+### 1) Temperature spike
+
+- Raw data:
+  - 20.5°C → **52.2°C** → 20.8°C
+- Threshold: `internal_temperature = 5.0`
+- Change: 52.2 – 20.5 ≈ 31.7 > 5.0 → Threshold outlier detected.
+
+**Original integration:**
+- State: 20.5 → 52.2 → 20.8  
+- Index: “good” → “terrible” → “good”  
+- Graph: Strong spike to 52°C.
+
+**v5 integration:**
+- State: 20.5 → median(history) ≈ 20.5 → 20.8  
+- Index: consistent “good” readings  
+- Graph: No erroneous 52°C spike.
+
+---
+
+### 2) TVOC zero-drop (multiple days)
+
+Example raw patterns:
+
+- 91.0 → **0.0**
+- 225.0 → **0.0**
+- 90.0 → **0.0**
+- 108.0 → **0.0**
+- 100.0 → **0.0**
+- 70.0 → **0.0**
+
+**Zero-drop detection:**
+- Previous value `> 20.0`, current value `< 1.0`  
+→ Zero-drop outlier detected (even though delta might be less than 150 for some cases).
+
+**Original integration:**
+- TVOC briefly drops to 0 → graph shows dips to 0 → misleading for interpretation.
+
+**v5 integration:**
+- For these readings:
+  - Marked as zero-drop outliers.
+  - Replaced by median of recent valid TVOC values (e.g. around previous level).
+  - Index stays consistent; no “fake fresh air” because of 0 TVOC.
+
+---
+
+### 3) Legitimate TVOC jump (allowed)
+
+From your data:
+
+- 196.0 → 96.0 (delta = 100.0)
+- Both values are reasonable and not near zero.
+
+With `OUTLIER_THRESHOLDS["tvoc"] = 150.0`:
+
+- `change = 100.0 < 150.0` → **no outlier**.
+- v5 will pass this as a normal reading.
+
+**Result:**
+- Sensor remains responsive to valid, large variations (e.g. airing a room, cooking, etc.).
+- Only obviously erroneous values (like sudden zeros) are filtered.
+
+---
+
+## File-level changes vs. original `sensor.py`
+
+Compared to the original integration file:
+
+- Added import:
+  - `from collections import deque`
+- Added new module-level constants:
+  - `OUTLIER_THRESHOLDS`
+  - `ZERO_DROP_CONFIG`
+  - `_FILTERED_VALUES`
+- In `async_setup_entry`:
+  - Initialization of `_FILTERED_VALUES[device_id]` for each device.
+- In `RadoffSensor.__init__`:
+  - New attributes for base sensors:
+    - `_value_history: deque` (size 3)
+    - `_last_valid_value`
+- New methods in `RadoffSensor`:
+  - `_calculate_median`
+  - `_is_outlier_detected` (with hybrid logic)
+  - `_get_filtered_base_value`
+  - `_store_filtered_value`
+- Modified `native_value`:
+  - Uses `_is_outlier_detected` to decide when to replace/suppress a value.
+  - Uses median/last_valid_value for replacements.
+  - Stores cleaned values in `_FILTERED_VALUES` for index sensors.
+  - Returns `None` if a reading is skipped.
+
+All other behavior (device info, translation keys, index mapping, etc.) retains the original design.
+
+---
+
+## Installation
+
+1. **Backup original:**
+cp custom_components/radoff/sensor.py custom_components/radoff/sensor.py.backup
+
+text
+
+2. **Replace with v5:**
+- Save this file as `sensor.py` in `custom_components/radoff/`.
+
+3. **(Optional) Adjust thresholds:**
+- Edit `OUTLIER_THRESHOLDS` and `ZERO_DROP_CONFIG` to match your environment.
+- For TVOC, keep:
+  ```
+  "tvoc": 150.0
+  ```
+  and rely on `ZERO_DROP_CONFIG` to catch zero-drops.
+
+4. **Restart Home Assistant:**
+- Via UI: Developer Tools → Services → *Homeassistant: Restart*  
+- Or via shell:
+  ```
+  sudo systemctl restart home-assistant
+  ```
+
+---
+
+## Logging and debugging
+
+Enable debug logging in `configuration.yaml`:
+
+logger:
+default: info
+logs:
+custom_components.radoff.sensor: debug
+
+text
+
+You will see:
+
+- Warnings for zero-drops and threshold outliers.
+- Info logs for median replacement.
+- Debug logs when index sensors are suppressed because base values were filtered.
+
+---
+
+## Summary
+
+v5 keeps your sensor behavior natural for normal operation, but:
+
+- Eliminates spurious TVOC zero readings.
+- Suppresses unrealistic spikes (e.g. 52°C).
+- Ensures index sensors always reflect cleaned, reliable values.
+- Provides tunable parameters for both general thresholds and special zero-drop detection.

--- a/README-outlier-detection.md
+++ b/README-outlier-detection.md
@@ -30,18 +30,18 @@ This version (v5) extends the original Radoff Now Home Assistant integration wit
 
 Used for general outlier detection based on change magnitude from the last valid value.
 
+```
 OUTLIER_THRESHOLDS: dict[str, float] = {
-"internal_temperature": 5.0, # Max 5°C change between readings
-"tvoc": 150.0, # Max 150 V-lx change
-"eco2": 500.0, # Max 500 ppm change
-"relative_humidity": 15.0, # Max 15% change
-"pm1": 50.0,
-"pm25": 50.0,
-"pm10": 50.0,
-"pressure": 1000.0, # Max 1000 Pa change
+	"internal_temperature": 5.0, # Max 5°C change between readings
+	"tvoc": 150.0, # Max 150 V-lx change
+	"eco2": 500.0, # Max 500 ppm change
+	"relative_humidity": 15.0, # Max 15% change
+	"pm1": 50.0,
+	"pm25": 50.0,
+	"pm10": 50.0,
+	"pressure": 1000.0, # Max 1000 Pa change
 }
-
-text
+```
 
 - These values can be tuned per sensor.
 - For TVOC, a relatively high threshold (150.0) is used so that legitimate large jumps (e.g. 196 → 96) are not suppressed.  
@@ -51,19 +51,13 @@ text
 
 Used for sensor-specific detection of “drops to zero / near-zero” from normal values.
 
+```
 ZERO_DROP_CONFIG: dict[str, dict[str, float]] = {
-"tvoc": {
-"low_threshold": 1.0, # Values below this are considered "zero"
-"normal_threshold": 20.0, # Previous value must be above this to trigger zero-drop detection
-},
-# Example for adding more:
-# "eco2": {
-# "low_threshold": 100.0,
-# "normal_threshold": 400.0,
-# },
+	"tvoc": {
+		"low_threshold": 1.0, # Values below this are considered "zero"
+		"normal_threshold": 20.0, # Previous value must be above this to trigger zero-drop detection
+	}
 }
-
-text
 
 **Effect for TVOC:**
 - If a reading goes from, for example, 70 → 0 or 225 → 0:

--- a/README-outlier-detection.md
+++ b/README-outlier-detection.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This change extends the original Radoff Now Home Assistant integration with robust outlier handling, while keeping normal sensor behavior unchanged. The change was introduced due to some implausible readings from my TVOC and Temperature sensor. 
+This change extends the original Radoff Now Home Assistant integration with robust outlier handling, while keeping normal sensor behavior unchanged. The change was introduced due to some implausible values in Home Assistant from my TVOC and Temperature sensor. 
 
 - TVOC had some drops to 0, especially early mornings
 - Temperature sensor sometimes peaks to temperature readings above 50°C

--- a/README-outlier-detection.md
+++ b/README-outlier-detection.md
@@ -2,7 +2,12 @@
 
 ## Overview
 
-This change extends the original Radoff Now Home Assistant integration with robust outlier handling, while keeping normal sensor behavior unchanged.
+This change extends the original Radoff Now Home Assistant integration with robust outlier handling, while keeping normal sensor behavior unchanged. The change was introduced due to some implausible readings from my TVOC and Temperature sensor. 
+
+- TVOC had some drops to 0, especially early mornings
+- Temperature sensor sometimes peaks to temperature readings above 50°C
+
+These readings are also stored in Radoff's IOT cloud and can be seen when downloading the data. It is unknown whether they are really transfered by the device or whether it is a flaw of the transfer of sensor data into the Radoff cloud. 
 
 **Key idea:**  
 - Normal readings are passed through as-is.  
@@ -13,7 +18,7 @@ This change extends the original Radoff Now Home Assistant integration with robu
 
 ## Changes compared to original code
 
-| Aspect | Original | v5 (this version) |
+| Aspect | Original | Outlier detection version (this version) |
 | --- | --- | --- |
 | Value processing | Raw sensor value is passed through | Raw value is used unless flagged as outlier |
 | Outlier detection | None | Hybrid: zero-drop rule + delta-threshold |
@@ -175,7 +180,7 @@ From your data:
 With `OUTLIER_THRESHOLDS["tvoc"] = 150.0`:
 
 - `change = 100.0 < 150.0` → **no outlier**.
-- v5 will pass this as a normal reading.
+- Outlier detection version will pass this as a normal reading.
 
 **Result:**
 - Sensor remains responsive to valid, large variations (e.g. airing a room, cooking, etc.).

--- a/custom_components/radoff/sensor.py
+++ b/custom_components/radoff/sensor.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import Callable
+from collections import deque
 from enum import StrEnum
 from numbers import Number
 from typing import Any
@@ -95,6 +96,31 @@ INDEX_MAPPING: dict[str, dict[str, Any]] = {
     },
 }
 
+# Threshold definitions for outlier detection (sensor_key -> max_allowed_change_per_update)
+OUTLIER_THRESHOLDS: dict[str, float] = {
+    "internal_temperature": 5.0,  # Max 5°C change between readings
+    "tvoc": 150.0,  # Max 150 V-lx change
+    "eco2": 500.0,  # Max 500 ppm change
+    "relative_humidity": 15.0,  # Max 15% change
+    "pm1": 50.0,
+    "pm25": 50.0,
+    "pm10": 50.0,
+    "pressure": 1000.0,  # Max 1000 Pa change
+}
+
+# Special configuration for detecting drops to zero/near-zero values
+# This catches sensor errors where value drops to 0 from normal readings
+ZERO_DROP_CONFIG: dict[str, dict[str, float]] = {
+    "tvoc": {
+        "low_threshold": 1.0,     # Values below this are considered "zero"
+        "normal_threshold": 20.0,  # Previous value must be above this to trigger zero-drop detection
+    }
+}
+
+# Shared filtered values storage per device
+# Structure: {device_id: {sensor_key: filtered_value_or_None}}
+_FILTERED_VALUES: dict[str, dict[str, float | int | None]] = {}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -110,6 +136,10 @@ async def async_setup_entry(
 
     sensors = []
     for device in coordinator.data.devices:
+        # Initialize filtered values storage for this device
+        if device.device_id not in _FILTERED_VALUES:
+            _FILTERED_VALUES[device.device_id] = {}
+
         for sensor in device.sensors.values():
             sensors.append(  # noqa: PERF401
                 RadoffSensor(
@@ -173,6 +203,9 @@ class RadoffSensor(CoordinatorEntity, SensorEntity):
         self.coordinator_context = coordinator_context
         self._is_index = is_index
         self._index_fn = index_fn
+        # History buffer for outlier detection (stores last 3 values) - ONLY for base sensors
+        self._value_history: deque = deque(maxlen=3) if not is_index else None
+        self._last_valid_value: float | int | None = None if not is_index else None
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -202,9 +235,97 @@ class RadoffSensor(CoordinatorEntity, SensorEntity):
         else:
             return f"{self.sensor_key}_index"
 
+    def _calculate_median(self, values: list) -> float | int:
+        """Calculate median of values."""
+        sorted_values = sorted(values)
+        n = len(sorted_values)
+        if n == 0:
+            return None
+        elif n % 2 == 1:
+            # Odd number of values
+            return sorted_values[n // 2]
+        else:
+            # Even number of values - average of middle two
+            mid1 = sorted_values[n // 2 - 1]
+            mid2 = sorted_values[n // 2]
+            if isinstance(sorted_values[0], int):
+                return int((mid1 + mid2) / 2)
+            else:
+                return (mid1 + mid2) / 2
+
+    def _is_outlier_detected(self, current_value: float | int) -> bool:
+        """Detect if value change exceeds threshold (outlier detection with hybrid method)."""
+        if self._last_valid_value is None:
+            # No previous value to compare
+            return False
+        # Check if this sensor has an outlier threshold defined
+        if self.sensor_key not in OUTLIER_THRESHOLDS:
+            # No threshold defined, accept all values
+            return False
+
+        # HYBRID METHOD: Check for zero-drop condition first (sensor-specific)
+        if self.sensor_key in ZERO_DROP_CONFIG:
+            config = ZERO_DROP_CONFIG[self.sensor_key]
+            low_threshold = config["low_threshold"]
+            normal_threshold = config["normal_threshold"]
+
+            # If current value drops to near-zero AND previous value was normal
+            # This catches sensor errors like TVOC dropping from 70 to 0
+            if current_value < low_threshold and self._last_valid_value > normal_threshold:
+                _LOGGER.warning(
+                    "Zero-drop outlier detected for %s (%s): value dropped from %s to %s (below %s, was above %s)",
+                    self.friendly_name,
+                    self.sensor_key,
+                    self._last_valid_value,
+                    current_value,
+                    low_threshold,
+                    normal_threshold
+                )
+                return True
+
+        # Standard threshold check for all other outliers
+        threshold = OUTLIER_THRESHOLDS[self.sensor_key]
+        change = abs(current_value - self._last_valid_value)
+        if change > threshold:
+            _LOGGER.warning(
+                "Threshold outlier detected for %s (%s): value changed from %s to %s (threshold: %s)",
+                self.friendly_name,
+                self.sensor_key,
+                self._last_valid_value,
+                current_value,
+                threshold
+            )
+            return True
+        return False
+
+    def _get_filtered_base_value(self) -> float | int | None:
+        """Get the current filtered value from shared storage."""
+        device_values = _FILTERED_VALUES.get(self.device.device_id, {})
+        return device_values.get(self.sensor_key)
+
+    def _store_filtered_value(self, value: float | int | None) -> None:
+        """Store filtered value in shared storage for index sensors to use."""
+        if self.device.device_id not in _FILTERED_VALUES:
+            _FILTERED_VALUES[self.device.device_id] = {}
+        _FILTERED_VALUES[self.device.device_id][self.sensor_key] = value
+
     @property
-    def native_value(self) -> int | float:
+    def native_value(self) -> int | float | str | None:
         """Return the state of the entity."""
+        # INDEX SENSOR - use filtered value from base sensor
+        if self._is_index:
+            filtered_val = self._get_filtered_base_value()
+            # If base sensor filtered out the value (None), don't send index either
+            if filtered_val is None:
+                _LOGGER.debug(
+                    "Index sensor %s: base value was filtered out, returning None",
+                    self.sensor_key
+                )
+                return None
+            # Apply index function to filtered value
+            return self._index_fn(filtered_val)
+        # BASE SENSOR - apply outlier detection and store result
+        # Get raw value
         val = None
 
         if self._normalize_fn is not None:
@@ -212,11 +333,49 @@ class RadoffSensor(CoordinatorEntity, SensorEntity):
         else:
             raw_val = self.device.sensors[self.sensor_key].value
             val = int(raw_val) if isinstance(raw_val, int) else float(raw_val)
-
-        if self._is_index:
-            return self._index_fn(val)
-        else:
-            return val
+        # Check for outlier detection
+        if self._is_outlier_detected(val):
+            # Outlier detected - use median of history as replacement
+            if len(self._value_history) > 0:
+                median_value = self._calculate_median(list(self._value_history))
+                _LOGGER.info(
+                    "Using median value %s for %s instead of outlier %s",
+                    median_value,
+                    self.sensor_key,
+                    val
+                )
+                # Don't add outlier to history
+                # Store median value for index sensor
+                self._store_filtered_value(median_value)
+                self._last_valid_value = median_value
+                return median_value
+            elif self._last_valid_value is not None:
+                # No history but have last valid value
+                _LOGGER.info(
+                    "Using last valid value %s for %s instead of outlier %s",
+                    self._last_valid_value,
+                    self.sensor_key,
+                    val
+                )
+                # Store last valid value for index sensor
+                self._store_filtered_value(self._last_valid_value)
+                return self._last_valid_value
+            else:
+                # No history and no last valid value - skip this reading
+                _LOGGER.warning(
+                    "Outlier detected for %s but no previous valid value, skipping this reading",
+                    self.sensor_key
+                )
+                # Store None to signal index sensor to also skip
+                self._store_filtered_value(None)
+                return None
+        # No outlier - use raw value directly
+        # Add to history for future outlier detection
+        self._value_history.append(val)
+        self._last_valid_value = val
+        # Store value for index sensor to use
+        self._store_filtered_value(val)
+        return val
 
     @property
     def native_unit_of_measurement(self) -> str | None:

--- a/custom_components/radoff/sensor.py
+++ b/custom_components/radoff/sensor.py
@@ -99,7 +99,7 @@ INDEX_MAPPING: dict[str, dict[str, Any]] = {
 # Threshold definitions for outlier detection (sensor_key -> max_allowed_change_per_update)
 OUTLIER_THRESHOLDS: dict[str, float] = {
     "internal_temperature": 5.0,  # Max 5°C change between readings
-    "tvoc": 150.0,  # Max 150 V-lx change
+    "tvoc": 300.0,  # Max 300 V-lx change
     "eco2": 500.0,  # Max 500 ppm change
     "relative_humidity": 15.0,  # Max 15% change
     "pm1": 50.0,


### PR DESCRIPTION
# Radoff Now Sensor – Outlier Detection

## Overview

This change extends the original Radoff Now Home Assistant integration with robust outlier handling, while keeping normal sensor behavior unchanged. The change was introduced due to some implausible values in Home Assistant from my TVOC and Temperature sensor.

- TVOC had some drops to 0, especially early mornings
- Temperature sensor sometimes peaks to temperature readings above 50°C

These readings are also stored in Radoff's IOT cloud and can be seen when downloading the data. It is unknown whether they are really transfered by the device or whether it is a flaw of the transfer of sensor data into the Radoff cloud.

**Key idea:**
- Normal readings are passed through as-is.
- Only detected outliers are replaced (using a small history-based median).
- Index sensors use the cleaned base values, not raw ones.
