### PR TITLE
Outlier detection and fix

### DIFF
--- a/custom_components/radoff/sensor.py
+++ b/custom_components/radoff/sensor.py
@@ -276,7 +276,13 @@ class RadoffSensor(CoordinatorEntity, SensorEntity):
                     drop_threshold,
                 )
                 return True
-
+                
+        _LOGGER.debug(
+            "No outlier detected in %s: %.2f to %.2f",
+            self.sensor_key,
+            last_valid,
+            current_value,
+        )
         return False
 
     @callback
@@ -323,7 +329,7 @@ class RadoffSensor(CoordinatorEntity, SensorEntity):
             val = int(raw_val) if isinstance(raw_val, int) else float(raw_val)
 
         # Apply outlier filter (uses shared state)
-        if self._outlier_filter_enabled:
+        if self._outlier_filter_enabled and not self._is_index:
             last_valid = _get_last_valid_value(self.device.device_id, self.sensor_key)
 
             # Initialize if first value

--- a/custom_components/radoff/sensor.py
+++ b/custom_components/radoff/sensor.py
@@ -31,12 +31,12 @@ OUTLIER_FILTER_CONFIG = {
         "enabled": True,
     },
     "eco2": {
-        "spike_threshold": 400,  # ppm
+        "spike_threshold": 500,  # ppm
         "drop_threshold": None,
         "enabled": True,
     },
     "tvoc": {
-        "spike_threshold": 150,  # V-lx
+        "spike_threshold": 200,  # V-lx
         "drop_threshold": 5.0,   # V-lx
         "enabled": True,
     },
@@ -150,6 +150,21 @@ def _increment_filter_count(device_id: str, sensor_key: str) -> int:
         _FILTER_STATE[key]["count"] = _FILTER_STATE[key].get("count", 0) + 1
     return _FILTER_STATE[key]["count"]
 
+def _reset_consecutive_count(device_id: str, sensor_key: str) -> None:
+    """Reset the consecutive outlier counter."""
+    key = _get_filter_state_key(device_id, sensor_key)
+    if key in _FILTER_STATE:
+        _FILTER_STATE[key]["consecutive"] = 0
+
+def _increment_consecutive_count(device_id: str, sensor_key: str) -> int:
+    """Increment consecutive outlier counter and return new count."""
+    key = _get_filter_state_key(device_id, sensor_key)
+    if key not in _FILTER_STATE:
+        # Initialisieren, falls noch nicht vorhanden
+        _FILTER_STATE[key] = {"last_valid": None, "count": 0, "consecutive": 1}
+    else:
+        _FILTER_STATE[key]["consecutive"] = _FILTER_STATE[key].get("consecutive", 0) + 1
+    return _FILTER_STATE[key]["consecutive"]
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -335,22 +350,42 @@ class RadoffSensor(CoordinatorEntity, SensorEntity):
             # Initialize if first value
             if last_valid is None:
                 _set_last_valid_value(self.device.device_id, self.sensor_key, val)
+                _reset_consecutive_count(self.device.device_id, self.sensor_key)
+
             elif self._is_outlier(val):
-                # Return last valid value instead of outlier
-                filter_count = _increment_filter_count(self.device.device_id, self.sensor_key)
-                _LOGGER.info(
-                    "Filtering outlier for %s%s: using %.2f instead of %.2f (filter activation #%d)",
-                    self.sensor_key,
-                    "_index" if self._is_index else "",
-                    last_valid,
-                    val,
-                    filter_count,
-                )
-                val = last_valid
+                # Outlier detected
+                consecutive = _increment_consecutive_count(self.device.device_id, self.sensor_key)
+                
+                # if three consecutive outliers occur, we accept the value as the new truth
+                if consecutive >= 3:
+                    _LOGGER.warning(
+                        "Outlier persisted for %d readings in %s. Accepting new value %.2f as valid (prev: %.2f).",
+                        consecutive,
+                        self.sensor_key,
+                        val,
+                        last_valid
+                    )
+                    _set_last_valid_value(self.device.device_id, self.sensor_key, val)
+                    _reset_consecutive_count(self.device.device_id, self.sensor_key)
+                    # val ist nun der neue korrekte Wert
+                else:
+                    # Return last valid value instead of outlier
+                    filter_count = _increment_filter_count(self.device.device_id, self.sensor_key)
+                    _LOGGER.info(
+                        "Filtering outlier for %s%s: using %.2f instead of %.2f (filter activation #%d, consecutive #%d)",
+                        self.sensor_key,
+                        "_index" if self._is_index else "",
+                        last_valid,
+                        val,
+                        filter_count,
+                        consecutive
+                    )
+                    val = last_valid
             else:
-                # Update last valid value (only from main sensor, not index)
+                # Valid value - update last valid and reset counter
                 if not self._is_index:
                     _set_last_valid_value(self.device.device_id, self.sensor_key, val)
+                    _reset_consecutive_count(self.device.device_id, self.sensor_key)
 
         # For index sensors, compute index from the (potentially filtered) value
         if self._is_index:

--- a/custom_components/radoff/sensor.py
+++ b/custom_components/radoff/sensor.py
@@ -1,4 +1,4 @@
-"""Class which represent the Radoff entity."""
+"""Class which represent the Radoff entity with outlier filtering."""
 
 import logging
 from collections.abc import Callable
@@ -22,6 +22,30 @@ from .const import DOMAIN
 from .coordinator import RadoffCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# Outlier filter configuration
+OUTLIER_FILTER_CONFIG = {
+    "internal_temperature": {
+        "spike_threshold": 5.0,  # °C
+        "drop_threshold": None,
+        "enabled": True,
+    },
+    "eco2": {
+        "spike_threshold": 400,  # ppm
+        "drop_threshold": None,
+        "enabled": True,
+    },
+    "tvoc": {
+        "spike_threshold": 150,  # V-lx
+        "drop_threshold": 5.0,   # V-lx
+        "enabled": True,
+    },
+}
+
+# Shared state for outlier filter (across sensor instances)
+# Key: f"{device_id}_{sensor_key}"
+# Value: {"last_valid": float, "count": int}
+_FILTER_STATE = {}
 
 INDEX_MAPPING: dict[str, dict[str, Any]] = {
     "tvoc": {
@@ -96,6 +120,37 @@ INDEX_MAPPING: dict[str, dict[str, Any]] = {
 }
 
 
+def _get_filter_state_key(device_id: str, sensor_key: str) -> str:
+    """Generate unique key for filter state."""
+    return f"{device_id}_{sensor_key}"
+
+
+def _get_last_valid_value(device_id: str, sensor_key: str) -> float | None:
+    """Get last valid value from shared state."""
+    key = _get_filter_state_key(device_id, sensor_key)
+    state = _FILTER_STATE.get(key)
+    return state["last_valid"] if state else None
+
+
+def _set_last_valid_value(device_id: str, sensor_key: str, value: float) -> None:
+    """Set last valid value in shared state."""
+    key = _get_filter_state_key(device_id, sensor_key)
+    if key not in _FILTER_STATE:
+        _FILTER_STATE[key] = {"last_valid": value, "count": 0}
+    else:
+        _FILTER_STATE[key]["last_valid"] = value
+
+
+def _increment_filter_count(device_id: str, sensor_key: str) -> int:
+    """Increment filter activation counter and return new count."""
+    key = _get_filter_state_key(device_id, sensor_key)
+    if key not in _FILTER_STATE:
+        _FILTER_STATE[key] = {"last_valid": None, "count": 1}
+    else:
+        _FILTER_STATE[key]["count"] = _FILTER_STATE[key].get("count", 0) + 1
+    return _FILTER_STATE[key]["count"]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -145,7 +200,7 @@ async def async_setup_entry(
 
 
 class RadoffSensor(CoordinatorEntity, SensorEntity):
-    """A sensor representing the radoff sensor entity."""
+    """A sensor representing the radoff sensor entity with outlier filtering."""
 
     _attr_has_entity_name = True
 
@@ -173,6 +228,56 @@ class RadoffSensor(CoordinatorEntity, SensorEntity):
         self.coordinator_context = coordinator_context
         self._is_index = is_index
         self._index_fn = index_fn
+
+        # Outlier filter enabled for this sensor type?
+        self._outlier_filter_enabled = (
+            sensor_key in OUTLIER_FILTER_CONFIG 
+            and OUTLIER_FILTER_CONFIG[sensor_key]["enabled"]
+        )
+
+    def _is_outlier(self, current_value: float | int) -> bool:
+        """
+        Check if current value is an outlier (spike or drop).
+        Returns True if the value should be filtered out.
+        Uses shared state across sensor instances.
+        """
+        if not self._outlier_filter_enabled:
+            return False
+
+        last_valid = _get_last_valid_value(self.device.device_id, self.sensor_key)
+        if last_valid is None:
+            return False
+
+        config = OUTLIER_FILTER_CONFIG[self.sensor_key]
+        spike_threshold = config.get("spike_threshold")
+        drop_threshold = config.get("drop_threshold")
+
+        # Check for spike (sudden large increase)
+        if spike_threshold is not None:
+            jump = current_value - last_valid
+            if abs(jump) > spike_threshold:
+                _LOGGER.debug(
+                    "Outlier detected in %s: spike from %.2f to %.2f (threshold: %.2f)",
+                    self.sensor_key,
+                    last_valid,
+                    current_value,
+                    spike_threshold,
+                )
+                return True
+
+        # Check for drop (sudden fall to near-zero)
+        if drop_threshold is not None:
+            if current_value <= drop_threshold and last_valid > drop_threshold * 1.5:
+                _LOGGER.debug(
+                    "Outlier detected in %s: drop from %.2f to %.2f (threshold: %.2f)",
+                    self.sensor_key,
+                    last_valid,
+                    current_value,
+                    drop_threshold,
+                )
+                return True
+
+        return False
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -203,8 +308,12 @@ class RadoffSensor(CoordinatorEntity, SensorEntity):
             return f"{self.sensor_key}_index"
 
     @property
-    def native_value(self) -> int | float:
-        """Return the state of the entity."""
+    def native_value(self) -> int | float | str:
+        """Return the state of the entity with outlier filtering.
+
+        The filter uses shared state so both main and index sensors
+        use the same filtered value.
+        """
         val = None
 
         if self._normalize_fn is not None:
@@ -213,6 +322,31 @@ class RadoffSensor(CoordinatorEntity, SensorEntity):
             raw_val = self.device.sensors[self.sensor_key].value
             val = int(raw_val) if isinstance(raw_val, int) else float(raw_val)
 
+        # Apply outlier filter (uses shared state)
+        if self._outlier_filter_enabled:
+            last_valid = _get_last_valid_value(self.device.device_id, self.sensor_key)
+
+            # Initialize if first value
+            if last_valid is None:
+                _set_last_valid_value(self.device.device_id, self.sensor_key, val)
+            elif self._is_outlier(val):
+                # Return last valid value instead of outlier
+                filter_count = _increment_filter_count(self.device.device_id, self.sensor_key)
+                _LOGGER.info(
+                    "Filtering outlier for %s%s: using %.2f instead of %.2f (filter activation #%d)",
+                    self.sensor_key,
+                    "_index" if self._is_index else "",
+                    last_valid,
+                    val,
+                    filter_count,
+                )
+                val = last_valid
+            else:
+                # Update last valid value (only from main sensor, not index)
+                if not self._is_index:
+                    _set_last_valid_value(self.device.device_id, self.sensor_key, val)
+
+        # For index sensors, compute index from the (potentially filtered) value
         if self._is_index:
             return self._index_fn(val)
         else:


### PR DESCRIPTION
If you experience spikes and zero-drops like me, this I how to fix it.

For me there are spikes in CO₂ and temperature as well as zero-drops in TVOC

I analyzed the last two weeks of October with 28.093 measurements and detected 24 outliers( 0.085%):

- Temperatur-Spikes (2): extreme jumps ~30°C
   - 17.10. 15:14: 22,77°C → 53,35°C → 22,75°C
   - 19.10. 20:12: 20,39°C → 50,66°C → 20,39°C
- CO₂-Spikes (9): jumps from ~410 to ~1180 ppm and back
  - constant pattern of ~760 ppm difference
- TVOC-Drops (13): values dropping to 0 and immediately back to previous value
  - mostly between 1am-4pm

After playing around with high-sophisticated logic (if you noticed my <deleted> issue and have seen the previous pull request :--)), it is now a pretty simplistic test. If an outlier is detected, the previous value will be reported. 

The filter is configurable and currently set up to fit to my needs.